### PR TITLE
consistency for Apple rules

### DIFF
--- a/Clash/Apple.list
+++ b/Clash/Apple.list
@@ -6,12 +6,14 @@ DOMAIN-SUFFIX,akadns.net
 DOMAIN-SUFFIX,apple-cloudkit.com
 DOMAIN-SUFFIX,apple.co
 DOMAIN-SUFFIX,apple.com
+DOMAIN-SUFFIX,apple.com.cn
 DOMAIN-SUFFIX,apple.news
 DOMAIN-SUFFIX,appstore.com
 DOMAIN-SUFFIX,cdn-apple.com
 DOMAIN-SUFFIX,crashlytics.com
 DOMAIN-SUFFIX,icloud-content.com
 DOMAIN-SUFFIX,icloud.com
+DOMAIN-SUFFIX,icloud.com.cn
 DOMAIN-SUFFIX,itunes.com
 DOMAIN-SUFFIX,me.com
 DOMAIN-SUFFIX,mzstatic.com

--- a/Clash/Providers/Ruleset/Apple.yaml
+++ b/Clash/Providers/Ruleset/Apple.yaml
@@ -7,12 +7,14 @@ payload:
   - DOMAIN-SUFFIX,apple-cloudkit.com
   - DOMAIN-SUFFIX,apple.co
   - DOMAIN-SUFFIX,apple.com
+  - DOMAIN-SUFFIX,apple.com.cn
   - DOMAIN-SUFFIX,apple.news
   - DOMAIN-SUFFIX,appstore.com
   - DOMAIN-SUFFIX,cdn-apple.com
   - DOMAIN-SUFFIX,crashlytics.com
   - DOMAIN-SUFFIX,icloud-content.com
   - DOMAIN-SUFFIX,icloud.com
+  - DOMAIN-SUFFIX,icloud.com.cn
   - DOMAIN-SUFFIX,itunes.com
   - DOMAIN-SUFFIX,me.com
   - DOMAIN-SUFFIX,mzstatic.com


### PR DESCRIPTION
When visiting `apple.com.cn` and `icloud.com.cn` , the attempt would match `DOMAIN-SUFFIX,cn,DIRECT` . However, these sites contain hosts with suffix `apple.com` ,which would match the Apple rule and would be treated with separate strategy group. Also, some other apple sites like `secure4.www.apple.com.cn` would match the final `MATCH` group.