### PR TITLE
Update YouTubeMusic.list

### DIFF
--- a/Clash/Ruleset/YouTubeMusic.list
+++ b/Clash/Ruleset/YouTubeMusic.list
@@ -1,6 +1,5 @@
 # 内容：YouTubeMusic
-# 数量：4条
-USER-AGENT,*YouTubeMusic*
-USER-AGENT,*com.google.ios.youtubemusic*
-USER-AGENT,YouTubeMusic*
-USER-AGENT,com.google.ios.youtubemusic*
+# 数量：3条
+- PROCESS-NAME,com.google.android.apps.youtube.music
+- PROCESS-NAME,com.google.android.youtube.tvmusicroot
+- PROCESS-NAME,com.vanced.android.apps.youtube.music


### PR DESCRIPTION
看clash的文档 https://github.com/Dreamacro/clash/wiki/configuration  rule似乎不支持user-agent的关键词，然后在cfw里手动添加了user-agent这四条规则也报错了，是5.8号的premium核
看openclash里也有youtubemusic的规则，不过它是写的process-name