### PR TITLE
remove: sm.ms, loli.net

### DIFF
--- a/Clash/ChinaDomain.list
+++ b/Clash/ChinaDomain.list
@@ -569,7 +569,6 @@ DOMAIN-SUFFIX,letitfly.me
 DOMAIN-SUFFIX,lizhi.fm
 DOMAIN-SUFFIX,lizhi.io
 DOMAIN-SUFFIX,lizhifm.com
-DOMAIN-SUFFIX,loli.net
 DOMAIN-SUFFIX,luoo.net
 DOMAIN-SUFFIX,lvmama.com
 DOMAIN-SUFFIX,lxdns.com
@@ -623,7 +622,6 @@ DOMAIN-SUFFIX,segmentfault.com
 DOMAIN-SUFFIX,sf-express.com
 DOMAIN-SUFFIX,shumilou.net
 DOMAIN-SUFFIX,simplecd.me
-DOMAIN-SUFFIX,sm.ms
 DOMAIN-SUFFIX,smzdm.com
 DOMAIN-SUFFIX,snwx.com
 DOMAIN-SUFFIX,soufunimg.com


### PR DESCRIPTION
SM.MS 和 loli.net 的服务器均在国外，且现已在部分地区受到污染，故移出直连列表。