### PR TITLE
fix:zhihu-miniprogram

### DIFF
--- a/Clash/BanProgramAD.list
+++ b/Clash/BanProgramAD.list
@@ -798,7 +798,6 @@ DOMAIN-SUFFIX,yads.yahoo.co.jp
 DOMAIN-SUFFIX,ybp.yahoo.com
 
 # Zhihu
-DOMAIN-SUFFIX,sugar.zhihu.com
 DOMAIN-SUFFIX,zhihu-web-analytics.zhihu.com
 
 # Ads in Video apps 下面都是 ********************


### PR DESCRIPTION
拦截`sugar.zhihu.com`该域名会导致知乎小程序查看不了问答(如下图)，放行该规则后可正常显示
![_cgi-bin_mmwebwx-bin_webwxgetmsgimg__ MsgID=6087676021212060447 skey=@crypt_cf59920_e96e16cd429a4dd3a644970f29d5b32d mmweb_appid=wx_webfilehelper](https://user-images.githubusercontent.com/28750658/164387661-8a89b39a-8d09-4230-a0b9-99b01582bf31.jpg)
