### PR TITLE
Update Sina.list

### DIFF
--- a/Clash/Ruleset/Sina.list
+++ b/Clash/Ruleset/Sina.list
@@ -1,10 +1,16 @@
 # 内容：Sina
-# 数量：8条
+# 数量：14条
 DOMAIN-SUFFIX,leju.com
 DOMAIN-SUFFIX,miaopai.com
 DOMAIN-SUFFIX,sina.com
+DOMAIN-SUFFIX,sina.com.cn
+DOMAIN-SUFFIX,sina.cn
 DOMAIN-SUFFIX,sinaapp.com
+DOMAIN-SUFFIX,sinaapp.cn
 DOMAIN-SUFFIX,sinaimg.com
+DOMAIN-SUFFIX,sinaimg.cn
 DOMAIN-SUFFIX,weibo.com
+DOMAIN-SUFFIX,weibo.cn
 DOMAIN-SUFFIX,weibocdn.com
+DOMAIN-SUFFIX,weibocdn.cn
 DOMAIN-SUFFIX,xiaoka.tv


### PR DESCRIPTION
既然是独立的新浪代理list，至少全面代理新浪微博客户端。补充了几个微博国际版的常用后缀。
不采用二级（三级）细分域名是因为多变且毫无必要区分。适合腰斩。