### PR TITLE
add amazon university jobs site

### DIFF
--- a/Clash/Ruleset/Amazon.list
+++ b/Clash/Ruleset/Amazon.list
@@ -1,5 +1,5 @@
 # 内容：Amazon
-# 数量：37条
+# 数量：38条
 DOMAIN-KEYWORD,avoddashs
 DOMAIN,atv-ps.amazon.com
 DOMAIN,avodmp4s3ww-a.akamaihd.net
@@ -17,6 +17,7 @@ DOMAIN-SUFFIX,aiv-delivery.net
 DOMAIN-SUFFIX,amazon.co.jp
 DOMAIN-SUFFIX,amazon.com
 DOMAIN-SUFFIX,amazon.jobs
+DOMAIN-SUFFIX,amazonuniversity.jobs
 DOMAIN-SUFFIX,amazonaws.com
 DOMAIN-SUFFIX,amazonvideo.com
 DOMAIN-SUFFIX,media-amazon.com


### PR DESCRIPTION
In addition to [https://amazon.jobs](https://amazon.jobs/), there is also a site to apply for jobs at Amazon that are just for students.