### PR TITLE
BanProgramAD规则导致mipush(小米推送)不能使用

### DIFF
--- a/Clash/BanProgramAD.list
+++ b/Clash/BanProgramAD.list
@@ -570,7 +570,6 @@ DOMAIN-SUFFIX,shenghuo.xiaomi.com
 DOMAIN-SUFFIX,stat.pandora.xiaomi.com
 DOMAIN-SUFFIX,union.mi.com
 DOMAIN-SUFFIX,wtradv.market.xiaomi.com
-DOMAIN-SUFFIX,xmpush.xiaomi.com
 
 # Moji
 DOMAIN-SUFFIX,ad.api.moji.com


### PR DESCRIPTION
QQ已经接入mipush，且mipush也用于接收咸鱼、酷安等平台的重要私信。屏蔽mipush可能影响部分APP使用体验。
将xmpush.xiaomi.com放行，QQ即使不在后台（关闭自启动），也可以通过mipush接收消息。