### PR TITLE
Update OpenAi.list

### DIFF
--- a/Clash/Ruleset/OpenAi.list
+++ b/Clash/Ruleset/OpenAi.list
@@ -6,4 +6,4 @@ DOMAIN-SUFFIX,challenges.cloudflare.com
 DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,openaiapi-site.azureedge.net
 DOMAIN-SUFFIX,stripe.com
-HOST-SUFFIX,http://sentry.io, OpenAI
+HOST-SUFFIX,http://sentry.io

--- a/Clash/Ruleset/OpenAi.list
+++ b/Clash/Ruleset/OpenAi.list
@@ -1,8 +1,9 @@
 # 内容：OpenAi
-# 数量：6条
+# 数量：7条
 DOMAIN-KEYWORD,openai
 DOMAIN-SUFFIX,ai.com
 DOMAIN-SUFFIX,challenges.cloudflare.com
 DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,openaiapi-site.azureedge.net
 DOMAIN-SUFFIX,stripe.com
+HOST-SUFFIX,http://sentry.io, OpenAI


### PR DESCRIPTION
增加sentry规则片段，经试验，Chatgpt网页版在使用过程中，js会向Sentry发送跨域请求，其中包含一个key，http://Sentry.io 是一个提供日志收集的第三方平台；发现Cloudflare和Sentry是有深度合作的，这可能因为检查使用者IP导致风控