### PR TITLE
增加欢太科技域名

### DIFF
--- a/Clash/ChinaDomain.list
+++ b/Clash/ChinaDomain.list
@@ -277,6 +277,15 @@ DOMAIN-SUFFIX,xiaomi.com
 DOMAIN-SUFFIX,xiaomi.net
 DOMAIN-SUFFIX,xiaomicp.com
 
+# Heytap
+DOMAIN-SUFFIX,heytap.com
+DOMAIN-SUFFIX,heytapmobi.com
+DOMAIN-SUFFIX,heytapdownload.com
+DOMAIN-SUFFIX,heytapcs.com
+DOMAIN-SUFFIX,oppomobile.com
+DOMAIN-SUFFIX,oppoer.me
+DOMAIN-SUFFIX,heytapimage.com
+
 # NetEase
 DOMAIN-SUFFIX,126.com
 DOMAIN-SUFFIX,126.net


### PR DESCRIPTION
OPPO PUSH依赖DNS解析，需要借助本地DNS解析，其应用程序的MQTT协议才能连接到国内可用的服务器。