### PR TITLE
ChinaDomain.list新增欢太科技(OPPO)域名

### DIFF
--- a/Clash/ChinaDomain.list
+++ b/Clash/ChinaDomain.list
@@ -214,6 +214,20 @@ DOMAIN-SUFFIX,hwccpc.com
 DOMAIN-SUFFIX,vmall.com
 DOMAIN-SUFFIX,vmallres.com
 
+# Heytap
+DOMAIN-SUFFIX,allawnfs.com
+DOMAIN-SUFFIX,allawno.com
+DOMAIN-SUFFIX,allawntech.com
+DOMAIN-SUFFIX,coloros.com
+DOMAIN-SUFFIX,heytap.com
+DOMAIN-SUFFIX,heytapcs.com
+DOMAIN-SUFFIX,heytapdownload.com
+DOMAIN-SUFFIX,heytapimage.com
+DOMAIN-SUFFIX,heytapmobi.com
+DOMAIN-SUFFIX,oppo.com
+DOMAIN-SUFFIX,oppoer.me
+DOMAIN-SUFFIX,oppomobile.com
+
 # Iflytek 科大讯飞
 DOMAIN-SUFFIX,iflyink.com
 DOMAIN-SUFFIX,iflyrec.com
@@ -581,7 +595,6 @@ DOMAIN-SUFFIX,nuomi.com
 DOMAIN-SUFFIX,onedns.net
 DOMAIN-SUFFIX,oneplus.com
 DOMAIN-SUFFIX,onlinedown.net
-DOMAIN-SUFFIX,oppo.com
 DOMAIN-SUFFIX,oracle.com
 DOMAIN-SUFFIX,oschina.net
 DOMAIN-SUFFIX,ourdvs.com


### PR DESCRIPTION
OPPO手机内部分系统业务（如OPPO PUSH）需要国内DNS才能解析出正确的IP。
未声明情况下，默认使用远程DNS，虽然可以解析出GeoCN的IP，但此类IP为清洗节点，无法正常使用。
P.S.欢太科技的域名太多、太杂，此次仅添加了个人已知在用的业务域名。