### PR TITLE
删除导致解析失败的规则

### DIFF
--- a/Clash/Providers/ProxyMedia.yaml
+++ b/Clash/Providers/ProxyMedia.yaml
@@ -156,7 +156,6 @@ payload:
 
   # HBO_GO_HKG
   # USER-AGENT,HBO%20GO%20PROD*
-  - DOMAIN-KEYWORD,.hbogoasia.
   - DOMAIN-KEYWORD,hbogoasia
   - DOMAIN,44wilhpljf.execute-api.ap-southeast-1.amazonaws.com
   - DOMAIN,bcbolthboa-a.akamaihd.net


### PR DESCRIPTION
被删除的规则会导致clash解析失败，且是重复的规则