### PR TITLE
Update OpenAi.list

### DIFF
--- a/Clash/Ruleset/OpenAi.list
+++ b/Clash/Ruleset/OpenAi.list
@@ -1,5 +1,5 @@
 # 内容：OpenAi
-# 数量：17条
+# 数量：15条
 DOMAIN-KEYWORD,openai
 DOMAIN-SUFFIX,auth0.com
 DOMAIN-SUFFIX,challenges.cloudflare.com
@@ -15,5 +15,3 @@ DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,openaiapi-site.azureedge.net
 DOMAIN-SUFFIX,sentry.io
 DOMAIN-SUFFIX,stripe.com
-DOMAIN-SUFFIX,oaistatic.com
-DOMAIN-SUFFIX,oaiusercontent.com

--- a/Clash/Ruleset/OpenAi.list
+++ b/Clash/Ruleset/OpenAi.list
@@ -1,5 +1,5 @@
 # 内容：OpenAi
-# 数量：15条
+# 数量：17条
 DOMAIN-KEYWORD,openai
 DOMAIN-SUFFIX,auth0.com
 DOMAIN-SUFFIX,challenges.cloudflare.com
@@ -15,3 +15,5 @@ DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,openaiapi-site.azureedge.net
 DOMAIN-SUFFIX,sentry.io
 DOMAIN-SUFFIX,stripe.com
+DOMAIN-SUFFIX,oaistatic.com
+DOMAIN-SUFFIX,oaiusercontent.com


### PR DESCRIPTION
ChatGPT/OpenAI新增两个域名，配置分流规则的朋友请及时更新

– DOMAIN-SUFFIX, oaistatic.com

– DOMAIN-SUFFIX, oaiusercontent.com