### PR TITLE
优化steam下载区域定位错误的问题

### DIFF
--- a/Clash/Ruleset/SteamRegionCheck.list
+++ b/Clash/Ruleset/SteamRegionCheck.list
@@ -1,0 +1,20 @@
+# 内容：Steam判断所属区域的服务器列表
+# 数量：16条
+# 直连以下域名，可以使Steam地区定位到中国，使用中国CDN，提高下载速度，但可能会影响跨区
+DOMAIN,ext1-hkg1.steamserver.net
+DOMAIN,ext2-hkg1.steamserver.net
+DOMAIN,ext3-hkg1.steamserver.net
+DOMAIN,ext4-hkg1.steamserver.net
+DOMAIN,ext5-hkg1.steamserver.net
+DOMAIN,ext6-hkg1.steamserver.net
+DOMAIN,ext7-hkg1.steamserver.net
+DOMAIN,ext1-tyo3.steamserver.net
+DOMAIN,ext2-tyo3.steamserver.net
+DOMAIN,ext3-tyo3.steamserver.net
+DOMAIN,ext4-tyo3.steamserver.net
+DOMAIN,ext1-sgp1.steamserver.net
+DOMAIN,ext2-sgp1.steamserver.net
+DOMAIN,ext3-sgp1.steamserver.net
+DOMAIN,ext4-sgp1.steamserver.net
+DOMAIN,ext1-lax1.steamserver.net
+DOMAIN,ext2-lax1.steamserver.net


### PR DESCRIPTION
增加一个有关Steam下载的规则集
这个规则集直连的时候，可以让steam正确定位到中国地域，使用中国CDN下载，提高下载速度
但定位到中国可能会导致跨区失败，所以没有写在SteamCN.list中，按需使用吧
#125 