### PR TITLE
Adding the current domain of OPTICA (formerly OSA)

### DIFF
--- a/Clash/Providers/Ruleset/Scholar.yaml
+++ b/Clash/Providers/Ruleset/Scholar.yaml
@@ -48,6 +48,7 @@ payload:
   - DOMAIN-SUFFIX,nature.com
   - DOMAIN-SUFFIX,ncbi.nlm.nih.gov
   - DOMAIN-SUFFIX,oecd-ilibrary.org
+  - DOMAIN-SUFFIX,opg.optica.org
   - DOMAIN-SUFFIX,osapublishing.org
   - DOMAIN-SUFFIX,oup.com
   - DOMAIN-SUFFIX,ovid.com

--- a/Clash/Ruleset/Scholar.list
+++ b/Clash/Ruleset/Scholar.list
@@ -47,6 +47,7 @@ DOMAIN-SUFFIX,myilibrary.com
 DOMAIN-SUFFIX,nature.com
 DOMAIN-SUFFIX,ncbi.nlm.nih.gov
 DOMAIN-SUFFIX,oecd-ilibrary.org
+DOMAIN-SUFFIX,opg.optica.org
 DOMAIN-SUFFIX,osapublishing.org
 DOMAIN-SUFFIX,oup.com
 DOMAIN-SUFFIX,ovid.com


### PR DESCRIPTION
Adding the current domain of OPTICA (formerly OSA), which is `opg.optica.org`.