### PR TITLE
Update MIUIPrivacy.list

### DIFF
--- a/Clash/Ruleset/MIUIPrivacy.list
+++ b/Clash/Ruleset/MIUIPrivacy.list
@@ -9,7 +9,6 @@ DOMAIN,sdkconf.avlyun.com
 DOMAIN,miav-cse.avlyun.com
 DOMAIN,api.installer.xiaomi.com
 DOMAIN,tmfsdk.m.qq.com
-DOMAIN,a0.app.xiaomi.com
 DOMAIN,etl-xlmc-ssl.sandai.net
 DOMAIN,cn.app.chat.xiaomi.net
 DOMAIN,idm.api.io.mi.com


### PR DESCRIPTION
屏蔽 a0.app.xiaomi.com 影响小米云备份功能使用。仅允许该项且屏蔽剩余条目后，仍可达到屏蔽安装检测的效果，似乎可以取消拉黑该条。