### PR TITLE
Update 去除ProxyMedia.list中OpenAi相关域名

### DIFF
--- a/Clash/ProxyMedia.list
+++ b/Clash/ProxyMedia.list
@@ -334,24 +334,6 @@ DOMAIN-SUFFIX,olevod.io
 DOMAIN-SUFFIX,olevod.tv
 DOMAIN-SUFFIX,olevodtv.com
 
-# OpenAi
-DOMAIN-KEYWORD,openai
-DOMAIN-SUFFIX,auth0.com
-DOMAIN-SUFFIX,challenges.cloudflare.com
-DOMAIN-SUFFIX,chatgpt.com
-DOMAIN-SUFFIX,client-api.arkoselabs.com
-DOMAIN-SUFFIX,events.statsigapi.net
-DOMAIN-SUFFIX,featuregates.org
-DOMAIN-SUFFIX,identrust.com
-DOMAIN-SUFFIX,intercom.io
-DOMAIN-SUFFIX,intercomcdn.com
-DOMAIN-SUFFIX,oaistatic.com
-DOMAIN-SUFFIX,oaiusercontent.com
-DOMAIN-SUFFIX,openai.com
-DOMAIN-SUFFIX,openaiapi-site.azureedge.net
-DOMAIN-SUFFIX,sentry.io
-DOMAIN-SUFFIX,stripe.com
-
 # PBS
 USER-AGENT,PBS*
 DOMAIN-SUFFIX,pbs.org


### PR DESCRIPTION
ProxyMedia.list中存在不相干的ai相关规则，与Clash/Ruleset/OpenAi.list冲突

https://github.com/ACL4SSR/ACL4SSR/issues/234