### PR TITLE
新增手机应用Chatgpt与Grok里用到的规则

### DIFF
--- a/Clash/Ruleset/AI.list
+++ b/Clash/Ruleset/AI.list
@@ -1,5 +1,5 @@
 # 内容：内容：AI平台-国外
-# 数量：39条
+# 数量：43条
 DOMAIN-KEYWORD,anthropic
 DOMAIN-KEYWORD,claude
 DOMAIN-KEYWORD,openai
@@ -39,3 +39,7 @@ DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,openaiapi-site.azureedge.net
 DOMAIN-SUFFIX,perplexity.ai
 DOMAIN-SUFFIX,sora.com
+DOMAIN-SUFFIX,api.revenuecat.com
+DOMAIN-SUFFIX,browser-intake-datadoghq.com
+DOMAIN-SUFFIX,featureassets.org
+DOMAIN-SUFFIX,intercom.com


### PR DESCRIPTION
新增的4个规则都是chatgpt与grok手机应用里捕获到的，日志信息如下：
[TCP] 127.0.0.1:57444(ai.x.grok) --> featureassets.org:443 match Match using 🐟 漏网之鱼[DIRECT]
[TCP] 127.0.0.1:38414(com.openai.chatgpt) --> api.revenuecat.com:443 match Match using 🐟 漏网之鱼[DIRECT]
[TCP] 127.0.0.1:37388(com.openai.chatgpt) --> browser-intake-datadoghq.com:443 match Match using 🐟 漏网之鱼[DIRECT]
[TCP] 127.0.0.1:52864(ai.x.grok) --> egv4py1c-android.mobile-messenger.intercom.com:443 match Match using DIRECT
经核都是进行用户信息收集、管理应用内订阅、事件日志记录与实时聊天客户支持等