### PR TITLE
clean up ad domains

### DIFF
--- a/Acl/backcn-banAD.acl
+++ b/Acl/backcn-banAD.acl
@@ -427,8 +427,8 @@
 (^|\.)jebe\.xnimg\.cn$
 
 # Sina
-(^|\.)(adimg|pay|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
-(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax|sax\d|slog)\.sina\.com(\.cn|)$
+(^|\.)(adimg|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
+(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax\d|slog)\.sina\.com(\.cn|)$
 (^|\.)(alitui|biz|game|wax)\.weibo\.com(\.cn|)$
 (^|\.)cre\.dp\.sina\.cn$
 (^|\.)gw5\.push\.mcp\.weibo\.cn$
@@ -1038,7 +1038,6 @@
 (^|\.)scupio\.com$
 (^|\.)shuiguo\.com$
 (^|\.)shuzilm\.cn$
-(^|\.)similarweb\.com$
 (^|\.)sitemeter\.com$
 (^|\.)sitescout\.com$
 (^|\.)sitetag\.us$

--- a/Acl/banAD.acl
+++ b/Acl/banAD.acl
@@ -422,8 +422,8 @@
 (^|\.)jebe\.xnimg\.cn$
 
 # Sina
-(^|\.)(adimg|pay|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
-(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax|sax\d|slog)\.sina\.com(\.cn|)$
+(^|\.)(adimg|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
+(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax\d|slog)\.sina\.com(\.cn|)$
 (^|\.)(alitui|biz|game|wax)\.weibo\.com(\.cn|)$
 (^|\.)cre\.dp\.sina\.cn$
 (^|\.)gw5\.push\.mcp\.weibo\.cn$
@@ -1032,7 +1032,6 @@
 (^|\.)scupio\.com$
 (^|\.)shuiguo\.com$
 (^|\.)shuzilm\.cn$
-(^|\.)similarweb\.com$
 (^|\.)sitemeter\.com$
 (^|\.)sitescout\.com$
 (^|\.)sitetag\.us$

--- a/Acl/easylist-banAD.acl
+++ b/Acl/easylist-banAD.acl
@@ -422,8 +422,8 @@
 (^|\.)jebe\.xnimg\.cn$
 
 # Sina
-(^|\.)(adimg|pay|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
-(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax|sax\d|slog)\.sina\.com(\.cn|)$
+(^|\.)(adimg|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
+(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax\d|slog)\.sina\.com(\.cn|)$
 (^|\.)(alitui|biz|game|wax)\.weibo\.com(\.cn|)$
 (^|\.)cre\.dp\.sina\.cn$
 (^|\.)gw5\.push\.mcp\.weibo\.cn$
@@ -1032,7 +1032,6 @@
 (^|\.)scupio\.com$
 (^|\.)shuiguo\.com$
 (^|\.)shuzilm\.cn$
-(^|\.)similarweb\.com$
 (^|\.)sitemeter\.com$
 (^|\.)sitescout\.com$
 (^|\.)sitetag\.us$

--- a/Acl/gfwlist-banAD.acl
+++ b/Acl/gfwlist-banAD.acl
@@ -417,8 +417,8 @@
 (^|\.)jebe\.xnimg\.cn$
 
 # Sina
-(^|\.)(adimg|pay|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
-(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax|sax\d|slog)\.sina\.com(\.cn|)$
+(^|\.)(adimg|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
+(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax\d|slog)\.sina\.com(\.cn|)$
 (^|\.)(alitui|biz|game|wax)\.weibo\.com(\.cn|)$
 (^|\.)cre\.dp\.sina\.cn$
 (^|\.)gw5\.push\.mcp\.weibo\.cn$
@@ -1027,7 +1027,6 @@
 (^|\.)scupio\.com$
 (^|\.)shuiguo\.com$
 (^|\.)shuzilm\.cn$
-(^|\.)similarweb\.com$
 (^|\.)sitemeter\.com$
 (^|\.)sitescout\.com$
 (^|\.)sitetag\.us$

--- a/Acl/onlybanAD.acl
+++ b/Acl/onlybanAD.acl
@@ -423,8 +423,8 @@
 (^|\.)jebe\.xnimg\.cn$
 
 # Sina
-(^|\.)(adimg|pay|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
-(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax|sax\d|slog)\.sina\.com(\.cn|)$
+(^|\.)(adimg|sax|sdkapp|sdkclick|trends|u1\.img|wbapp|wbclick|wbpctips)\.mobile\.sina\.cn$
+(^|\.)(ad|ad\d|adbox|adm|d\d|dcads|dmp|leju|sax\d|slog)\.sina\.com(\.cn|)$
 (^|\.)(alitui|biz|game|wax)\.weibo\.com(\.cn|)$
 (^|\.)cre\.dp\.sina\.cn$
 (^|\.)gw5\.push\.mcp\.weibo\.cn$
@@ -1033,7 +1033,6 @@
 (^|\.)scupio\.com$
 (^|\.)shuiguo\.com$
 (^|\.)shuzilm\.cn$
-(^|\.)similarweb\.com$
 (^|\.)sitemeter\.com$
 (^|\.)sitescout\.com$
 (^|\.)sitetag\.us$

--- a/Clash/BanAD.list
+++ b/Clash/BanAD.list
@@ -320,7 +320,6 @@ DOMAIN-SUFFIX,sanya1.com
 DOMAIN-SUFFIX,scupio.com
 DOMAIN-SUFFIX,shuiguo.com
 DOMAIN-SUFFIX,shuzilm.cn
-DOMAIN-SUFFIX,similarweb.com
 DOMAIN-SUFFIX,sitemeter.com
 DOMAIN-SUFFIX,sitescout.com
 DOMAIN-SUFFIX,sitetag.us

--- a/Clash/BanProgramAD.list
+++ b/Clash/BanProgramAD.list
@@ -638,9 +638,7 @@ DOMAIN-SUFFIX,leju.sina.com.cn
 DOMAIN-SUFFIX,log.mix.sina.com.cn
 DOMAIN-SUFFIX,mobileads.dx.cn
 DOMAIN-SUFFIX,newspush.sinajs.cn
-DOMAIN-SUFFIX,pay.mobile.sina.cn
 DOMAIN-SUFFIX,sax.mobile.sina.cn
-DOMAIN-SUFFIX,sax.sina.com.cn
 DOMAIN-SUFFIX,saxd.sina.com.cn
 DOMAIN-SUFFIX,sdkapp.mobile.sina.cn
 DOMAIN-SUFFIX,sdkapp.uve.weibo.com

--- a/Clash/Providers/BanAD.yaml
+++ b/Clash/Providers/BanAD.yaml
@@ -321,7 +321,6 @@ payload:
   - DOMAIN-SUFFIX,scupio.com
   - DOMAIN-SUFFIX,shuiguo.com
   - DOMAIN-SUFFIX,shuzilm.cn
-  - DOMAIN-SUFFIX,similarweb.com
   - DOMAIN-SUFFIX,sitemeter.com
   - DOMAIN-SUFFIX,sitescout.com
   - DOMAIN-SUFFIX,sitetag.us

--- a/Clash/Providers/BanProgramAD.yaml
+++ b/Clash/Providers/BanProgramAD.yaml
@@ -639,9 +639,7 @@ payload:
   - DOMAIN-SUFFIX,log.mix.sina.com.cn
   - DOMAIN-SUFFIX,mobileads.dx.cn
   - DOMAIN-SUFFIX,newspush.sinajs.cn
-  - DOMAIN-SUFFIX,pay.mobile.sina.cn
   - DOMAIN-SUFFIX,sax.mobile.sina.cn
-  - DOMAIN-SUFFIX,sax.sina.com.cn
   - DOMAIN-SUFFIX,saxd.sina.com.cn
   - DOMAIN-SUFFIX,sdkapp.mobile.sina.cn
   - DOMAIN-SUFFIX,sdkapp.uve.weibo.com


### PR DESCRIPTION
- `pay.mobile.sina.cn`: 新浪支付[相关](https://cn-sec.com/archives/27172.html)，不知道为什么被当作广告
- `sax.sina.com.cn`: 拦截后会造成 `https://video.sina.com.cn/` 上的[视频无法播放](https://github.com/privacy-protection-tools/anti-AD/issues/155)，easylistchina 也[加白](https://github.com/easylist/easylistchina/blob/c8210df54e68dae472c8718e80dd10b12e9e41c7/easylistchina.txt#L16421)了
- `similarweb.com`: fix #317
