### PR TITLE
Add accountboy.com to GFW list

### DIFF
--- a/Clash/ProxyGFWlist.list
+++ b/Clash/ProxyGFWlist.list
@@ -61,6 +61,7 @@ DOMAIN-KEYWORD,youtube
 
 # GFW list
 DOMAIN-SUFFIX,gfwlist.start
+DOMAIN-SUFFIX,accountboy.com
 DOMAIN-SUFFIX,000webhost.com
 DOMAIN-SUFFIX,030buy.com
 DOMAIN-SUFFIX,0rz.tw


### PR DESCRIPTION
Please add accountboy.com to proxy rules.

Domain:
accountboy.com

Expected behavior:
Traffic to accountboy.com and its subdomains should go through proxy.

Reason:
The domain is unreachable / unstable from mainland China without proxy, but works through proxy.