### PR TITLE
Add cn.download.nvidia.com to ChinaDomain.list

### DIFF
--- a/Clash/ChinaDomain.list
+++ b/Clash/ChinaDomain.list
@@ -724,3 +724,5 @@ DOMAIN-SUFFIX,zhongsou.com
 DOMAIN-SUFFIX,zhuihd.com
 DOMAIN-SUFFIX,cmbchina.com
 DOMAIN-SUFFIX,95516.com
+
+DOMAIN,cn.download.nvidia.com


### PR DESCRIPTION
该域名应为国内CDN，用于驱动程序下载等，个人实测直连没有速度问题，认为可以直连，无需代理