### PR TITLE
新增 Kwai/PayPalStripe/Speedtest/Weather 规则，补充 NaSDDNS

### DIFF
--- a/Clash/Ruleset/Kwai.list
+++ b/Clash/Ruleset/Kwai.list
@@ -1,0 +1,10 @@
+# 内容：Kwai 快手海外
+# 数量：8条
+DOMAIN-SUFFIX,kwai.com
+DOMAIN-SUFFIX,kwai.net
+DOMAIN-SUFFIX,kwai-pro.com
+DOMAIN-SUFFIX,ap4r.com
+DOMAIN-SUFFIX,ksapisrv.com
+DOMAIN-SUFFIX,fw-cdn.com
+DOMAIN-SUFFIX,kuaishou.com
+DOMAIN-SUFFIX,yximgs.com

--- a/Clash/Ruleset/NaSDDNS.list
+++ b/Clash/Ruleset/NaSDDNS.list
@@ -48,3 +48,37 @@ IP-CIDR,52.200.32.0/24,no-resolve
 IP-CIDR,52.86.69.0/24,no-resolve
 IP-CIDR,54.159.2.0/24,no-resolve
 IP-CIDR,54.166.1.0/24,no-resolve
+
+# > DDNS 服务商
+DOMAIN-SUFFIX,ddns.oray.com
+DOMAIN-SUFFIX,myqnapcloud.io
+DOMAIN-KEYWORD,myqnapcloud
+
+# > 公网 IP 检测服务
+DOMAIN-SUFFIX,ip.threep.top
+DOMAIN-SUFFIX,ip.3322.net
+DOMAIN-SUFFIX,ip.atomo.cn
+DOMAIN-SUFFIX,ip.ddnspod.com
+DOMAIN-SUFFIX,4.ipw.cn
+DOMAIN-SUFFIX,ipv4.ip.mir6.com
+DOMAIN-SUFFIX,ipplus360.com
+DOMAIN-SUFFIX,test.ipw.cn
+DOMAIN-SUFFIX,ifconfig.me
+DOMAIN-SUFFIX,ifconfig.es
+DOMAIN-SUFFIX,icanhazip.com
+DOMAIN-SUFFIX,ipinfo.io
+DOMAIN-SUFFIX,ipecho.net
+DOMAIN-SUFFIX,ident.me
+DOMAIN-SUFFIX,eth0.me
+DOMAIN-SUFFIX,ipaddr.site
+DOMAIN-SUFFIX,ipaddress.sh
+DOMAIN-SUFFIX,l2.io
+DOMAIN-SUFFIX,tnx.nl
+DOMAIN-SUFFIX,wgetip.com
+DOMAIN-SUFFIX,ip.tyk.nu
+DOMAIN-SUFFIX,curlmyip.net
+DOMAIN-SUFFIX,ipcalf.com
+DOMAIN-SUFFIX,checkip.amazonaws.com
+DOMAIN-SUFFIX,ip.sb
+DOMAIN-SUFFIX,nsupdate.info
+DOMAIN-SUFFIX,ipify.org

--- a/Clash/Ruleset/PayPalStripe.list
+++ b/Clash/Ruleset/PayPalStripe.list
@@ -1,0 +1,9 @@
+# > PayPal&Stripe
+USER-AGENT,PayPal*
+DOMAIN-SUFFIX,paypal.com
+DOMAIN-SUFFIX,paypal.me
+DOMAIN-SUFFIX,paypal-mktg.com
+DOMAIN-SUFFIX,paypalobjects.com
+DOMAIN-SUFFIX,stripecdn.com
+DOMAIN-SUFFIX,stripe.com
+DOMAIN-SUFFIX,stripe.network

--- a/Clash/Ruleset/Speedtest.list
+++ b/Clash/Ruleset/Speedtest.list
@@ -1,0 +1,19 @@
+# 内容：Speedtest
+# > Fast
+DOMAIN-SUFFIX,fast.com
+
+# > Speedtest by Ookla
+USER-AGENT,SpeedTest*
+DOMAIN-KEYWORD,speedtest
+DOMAIN-SUFFIX,ooklaserver.net
+DOMAIN-SUFFIX,cdnst.net
+DOMAIN-SUFFIX,pingtest.net
+DOMAIN-SUFFIX,speedtestcustom.com
+DOMAIN-SUFFIX,speedtest.net
+
+# > Speed Test by Cloudflare
+DOMAIN-SUFFIX,speed.cloudflare.com
+
+# > Speedtest CN
+DOMAIN-SUFFIX,speedtest.cn
+DOMAIN-SUFFIX,librespeed.cn

--- a/Clash/Ruleset/Weather.list
+++ b/Clash/Ruleset/Weather.list
@@ -1,0 +1,5 @@
+# 内容：Weather
+# 数量：5条
+DOMAIN-SUFFIX,wunderground.com
+DOMAIN-SUFFIX,weather.com
+DOMAIN-KEYWORD,weather


### PR DESCRIPTION
## 说明

新增 4 个规则集，并向现有 NaSDDNS.list 补充 DDNS 与公网 IP 检测域名。

## 新增文件

### Kwai.list
快手海外版。与现有 \`Kuaishou.list\`（大陆版）为同一公司的两个独立产品，类似 TikTok 与抖音的关系，故独立成文件而非合并。
- \`kwai.com\` / \`kwai.net\` / \`kwai-pro.com\` 等海外域名

### PayPalStripe.list
PayPal 与 Stripe 支付服务。

### Speedtest.list
测速服务集合：Fast（Netflix）、Speedtest by Ookla、Cloudflare Speed Test、LibreSpeed。

### Weather.list
天气服务：Weather.com、Wunderground。

## 补充文件

### NaSDDNS.list
在现有基础上新增：
- **DDNS 服务商**：\`ddns.oray.com\`、\`myqnapcloud.io\` 等
- **公网 IP 检测服务**：\`ifconfig.me\`、\`ipify.org\`、\`icanhazip.com\`、\`ip.sb\` 等

**理由**：DDNS 与公网 IP 检测属同一类需求——NAS 的 DDNS 功能依赖获取真实公网 IP 才能工作，二者常配合使用。

## 类型
- [x] 新增规则
- [x] 补充现有规则