### PR TITLE
将steamserver.net修改为直连

### DIFF
--- a/Clash/ProxyLite.list
+++ b/Clash/ProxyLite.list
@@ -388,7 +388,6 @@ DOMAIN-SUFFIX,steam-chat.com
 DOMAIN-SUFFIX,steamcommunity.com
 DOMAIN-SUFFIX,steamgames.com
 DOMAIN-SUFFIX,steampowered.com
-DOMAIN-SUFFIX,steamserver.net
 DOMAIN-SUFFIX,steamstatic.com
 DOMAIN-SUFFIX,steamstat.us
 DOMAIN,steambroadcast.akamaized.net

--- a/Clash/Ruleset/Steam.list
+++ b/Clash/Ruleset/Steam.list
@@ -13,7 +13,6 @@ DOMAIN-SUFFIX,steam-chat.com
 DOMAIN-SUFFIX,steamcommunity.com
 DOMAIN-SUFFIX,steamgames.com
 DOMAIN-SUFFIX,steampowered.com
-DOMAIN-SUFFIX,steamserver.net
 DOMAIN-SUFFIX,steamstat.us
 DOMAIN-SUFFIX,steamstatic.com
 DOMAIN-SUFFIX,underlords.com

--- a/Clash/Ruleset/SteamCN.list
+++ b/Clash/Ruleset/SteamCN.list
@@ -1,5 +1,5 @@
 # 内容：SteamCN
-# 数量：16条
+# 数量：17条
 DOMAIN,csgo.wmsj.cn
 DOMAIN,dl.steam.clngaa.com
 DOMAIN,dl.steam.ksyna.com
@@ -16,3 +16,4 @@ DOMAIN-SUFFIX,cm.steampowered.com
 DOMAIN-SUFFIX,steamchina.com
 DOMAIN-SUFFIX,steamcontent.com
 DOMAIN-SUFFIX,steamusercontent.com
+DOMAIN-SUFFIX,steamserver.net


### PR DESCRIPTION
steamserver.net这条域名需要修改成直连，否则steam会判定到境外的服务器下载