### PR TITLE
Add grok.com to AI ruleset

### DIFF
--- a/Clash/Ruleset/AI.list
+++ b/Clash/Ruleset/AI.list
@@ -1,5 +1,5 @@
 # 内容：内容：AI平台-国外
-# 数量：47条
+# 数量：48条
 DOMAIN-KEYWORD,anthropic
 DOMAIN-KEYWORD,claude
 DOMAIN-KEYWORD,openai
@@ -33,6 +33,7 @@ DOMAIN-SUFFIX,featuregates.org
 DOMAIN-SUFFIX,gemini.google.com
 DOMAIN-SUFFIX,grazie.ai
 DOMAIN-SUFFIX,grazie.aws.intellij.net
+DOMAIN-SUFFIX,grok.com
 DOMAIN-SUFFIX,identrust.com
 DOMAIN-SUFFIX,intercom.io
 DOMAIN-SUFFIX,intercomcdn.com


### PR DESCRIPTION
## What changed

- Add `DOMAIN-SUFFIX,grok.com` to the AI ruleset.
- Update the rule count from 47 to 48.

## Why

The Grok web app uses `grok.com` and subdomains such as `cdn.grok.com`. The existing `DOMAIN-SUFFIX,x.ai` entry only covers `x.ai` and its subdomains, so Grok web traffic falls through to the generic proxy rules instead of the AI policy group.

## Validation

- Confirmed the current AI ruleset does not contain `grok.com`.
- Observed active Grok connections to `grok.com` and `cdn.grok.com`.
- Used `DOMAIN-SUFFIX` so both the apex domain and its subdomains are covered.
