### PR TITLE
Add soundcloud.cloud to SoundCloud rules

### DIFF
--- a/Clash/Providers/Ruleset/SoundCloud.yaml
+++ b/Clash/Providers/Ruleset/SoundCloud.yaml
@@ -4,4 +4,5 @@ payload:
   #   
   - DOMAIN-SUFFIX,p-cdn.us
   - DOMAIN-SUFFIX,sndcdn.com
+  - DOMAIN-SUFFIX,soundcloud.cloud
   - DOMAIN-SUFFIX,soundcloud.com

--- a/Clash/Ruleset/SoundCloud.list
+++ b/Clash/Ruleset/SoundCloud.list
@@ -2,4 +2,5 @@
 # 数量：4条
 DOMAIN-SUFFIX,p-cdn.us
 DOMAIN-SUFFIX,sndcdn.com
+DOMAIN-SUFFIX,soundcloud.cloud
 DOMAIN-SUFFIX,soundcloud.com


### PR DESCRIPTION
  ## Summary

  Add `soundcloud.cloud` to the SoundCloud ruleset.

  ## Reason

  SoundCloud uses subdomains under `soundcloud.cloud`, such as
  `assets.web.soundcloud.cloud` and
  `playback.media-streaming.soundcloud.cloud`.

  `DOMAIN-SUFFIX,soundcloud.cloud` covers the domain and its subdomains.

  ## Changes

  - Added `soundcloud.cloud` to `Clash/Ruleset/SoundCloud.list`
  - Added `soundcloud.cloud` to `Clash/Providers/Ruleset/SoundCloud.yaml`